### PR TITLE
Add option to to bypass container hash checks

### DIFF
--- a/sr_u2s/__main__.py
+++ b/sr_u2s/__main__.py
@@ -23,6 +23,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-i", "--input-uwp-save-directory", help="Snowrunner Windows Store savegame directory", required=True)
     parser.add_argument("-o", "--output-steam-save-directory", help="Snowrunner Steam savegame directory", required=True)
+    parser.add_argument("--bypass-hash-check", help="Continue running even when the container file is incomplete ; may yield corrupted output files", action="store_true", default=False)
     parser.add_argument("-v", "--version", action="version", version=__version__)
     args = parser.parse_args()
 
@@ -31,7 +32,7 @@ if __name__ == "__main__":
     if not os.path.exists(input_dir) or not os.path.isdir(input_dir):
         parser.error(f"Error accessing {input_dir}")
     container_path = locate_container(input_dir)
-    save_list = container.load_container(locate_container(input_dir))
+    save_list = container.load_container(locate_container(input_dir), args.bypass_hash_check)
     print(f"Container file {container_path} loaded.")
     output_subdir = os.path.join(args.output_steam_save_directory, "1465360", "remote")
     os.makedirs(output_subdir, exist_ok=True)

--- a/sr_u2s/container.py
+++ b/sr_u2s/container.py
@@ -14,21 +14,26 @@ def decode_hash(hash_bytes):
     new_hash_bytes.append(hash_bytes[6])
     return new_hash_bytes.hex().upper() + hash_bytes[8:].hex().upper()
 
-def parse_file_bytes(bytes):
+def parse_file_bytes(bytes, bypass_hash_check):
     filepath = bytes[:-32].decode("utf-16").strip("\x00")
     hash1 = decode_hash(bytes[-32:-16])
     hash2 = decode_hash(bytes[-16:])
     if hash1 != hash2:
-        raise ValueError(f"Inconsistent hash for {filepath}")
-    return filepath, hash1
+        if not bypass_hash_check:
+            raise ValueError(f"Inconsistent hash for {filepath}")
+        if hash1 == "0" * 32:
+            print(f"Warning: no hash check for {filepath}")
+        else:
+            print(f"Warning: hash check failed for {filepath}")
+    return filepath, hash2
 
-def load_container(container_path):
+def load_container(container_path, bypass_hash_check=False):
     save_files = []
     with open(container_path, "rb") as containerfile:
         _header = struct.unpack("I", containerfile.read(4))[0]
         numfiles = struct.unpack("I", containerfile.read(4))[0]
         for i in range(numfiles):
-            save_files.append(parse_file_bytes(containerfile.read(160)))
+            save_files.append(parse_file_bytes(containerfile.read(160), bypass_hash_check))
     return save_files
 
 if __name__=="__main__":

--- a/sr_u2s/container.py
+++ b/sr_u2s/container.py
@@ -39,7 +39,8 @@ def load_container(container_path, bypass_hash_check=False):
 if __name__=="__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input-container", help="UWP container.xyz file", required=True)
+    parser.add_argument("--bypass-hash-check", help="Continue running even when the container file is incomplete ; may yield corrupted output files", action="store_true", default=False)
     args = parser.parse_args()
 
-    save_list = load_container(args.input_container)
+    save_list = load_container(args.input_container, args.bypass_hash_check)
     print(save_list)


### PR DESCRIPTION
A user has reported that his container sometimes triggered errors.
[container.zip](https://github.com/NeryK/snowrunner-uwp2steam/files/11069829/container.zip)

For each file listed in the container file, I had noticed that the obfuscated name (looks like a hash) is repeated twice. So I had a consistency check in place. This check seems to fail while the game is running, or maybe cloud sync is running.

```
py -m sr_u2s.container --input-container=C:\Temp\container.253
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "F:\src\snowrunner-uwp2steam\sr_u2s\container.py", line 45, in <module>
    save_list = load_container(args.input_container, args.bypass_hash_check)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "F:\src\snowrunner-uwp2steam\sr_u2s\container.py", line 36, in load_container
    save_files.append(parse_file_bytes(containerfile.read(160), bypass_hash_check))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "F:\src\snowrunner-uwp2steam\sr_u2s\container.py", line 23, in parse_file_bytes
    raise ValueError(f"Inconsistent hash for {filepath}")
ValueError: Inconsistent hash for CommonSslSave
```

The value of the first obfuscated name is either zeroes or another value entirely, while the second always seems to match an existing file. With that in mind I added an option to bypass the consistency check and always use the second value.

```
py -m sr_u2s.container --input-container=C:\Temp\container.253 --bypass-hash-check
Warning: hash check failed for CommonSslSave
Warning: hash check failed for CompleteSave
Warning: hash check failed for achievements
Warning: hash check failed for sts_level_ru_02_02
Warning: hash check failed for user_profile
Warning: hash check failed for user_social_data
[('CommonSslSave', '1174797E34D8447ABA078411C1FB1DC3'), ('CompleteSave', '0BD5CE875B0B45D89E2BD72E80906436'), ('achievements', 'F1901A80B2EF4FA2BBC1FC2992515CBB'), ('fog_level_ru_02_02', '2F1F7A62A43F4E11B47D4E946F6F7349'), ('fog_level_us_01_01', 'C9CE106B310B4B4BBBFBE5B00DCDC180'), ('fog_level_us_01_02', '06950D4EFE174402A4C1E72777B87F26'), ('fog_level_us_01_03', '951E59F097A3421699C994B10459A326'), ('fog_level_us_01_04_new', 'A47D0A68E7C0495889ED641AF78CF861'), ('fog_level_us_02_01', '8E31784B1F934080968ABB216E8D1293'), ('sts_level_ru_02_02', 'E7D5A83838AF4D81A901BA61420DF1F9'), ('sts_level_us_01_01', 'B01207F5D51348F59BCC69B0A2F39682'), ('sts_level_us_01_02', '10A9EABC456B4362A448B4251A4D9714'), ('sts_level_us_01_03', '7C3E626ABF8D42FB8AEC29E2D5E6098F'), ('sts_level_us_01_04_new', '65FC369EAF9148B6B792060532186CC8'), ('sts_level_us_02_01', '2B7FEC51F8B5491C99436636C82C8FC5'), ('user_profile', '300B953967F44851B52CA8BAE03526FC'), ('user_settings', '3A0D7EB7E0E3482FB7A4AEE48FFB36B8'), ('user_social_data', '664DC6E2422A44F88703ECC90963373B'), ('video', '814868237E2D4D8F9DD0EE29652625AB')]
```

